### PR TITLE
Set up Coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 install:
   - mvn clean install -DskipTests
 script:
-  - mvn surefire:test
+  - mvn jacoco:prepare-agent surefire:test jacoco:report coveralls:report
 cache:
   directories:
     # The local Maven repository in which third party dependencies are stored.

--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ Observable<String> mapped = dataStream.map(String::toUpperCase);
 Contributions are welcome! Feel free to file an [issue][new-issue] or open a
 [pull request][new-pr].
 
-When submitting code, please make every effort to follow existing conventions
-and style in order to keep the code as readable as possible.
+When submitting changes, please make every effort to follow existing
+conventions and style in order to keep the code as readable as possible. New
+code must be covered by tests. As a rule of thumb, overall test coverage should
+not decrease. (There are exceptions to this rule, e.g. when more code is
+deleted than added.)
 
 [coveralls-badge]: https://coveralls.io/repos/github/PicnicSupermarket/reactive-support/badge.svg?branch=master
 [coveralls-stats]: https://coveralls.io/github/PicnicSupermarket/reactive-support

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status][travisci-badge]][travisci-builds]
 [![Maven Central][maven-central-badge]][maven-central-browse]
+[![Coverage][coveralls-badge]][coveralls-stats]
 
 A collection of Reactive Programming (RxJava and Reactor) utilities forged and
 implemented in the Picnic backend.
@@ -145,6 +146,8 @@ Contributions are welcome! Feel free to file an [issue][new-issue] or open a
 When submitting code, please make every effort to follow existing conventions
 and style in order to keep the code as readable as possible.
 
+[coveralls-badge]: https://coveralls.io/repos/github/PicnicSupermarket/reactive-support/badge.svg?branch=master
+[coveralls-stats]: https://coveralls.io/github/PicnicSupermarket/reactive-support
 [flowable-retrywhen]: http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Flowable.html#retryWhen-io.reactivex.functions.Function-
 [jitpack]: https://jitpack.io
 [maven-central-badge]: https://img.shields.io/maven-central/v/tech.picnic.reactive-support/reactive-support.svg

--- a/pom.xml
+++ b/pom.xml
@@ -665,6 +665,11 @@
                     <version>1.0.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>4.3.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>
                     <version>1.6.0</version>
@@ -681,6 +686,11 @@
                         <failOnViolations>false</failOnViolations>
                         <javaVersion>${version.jdk}</javaVersion>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>


### PR DESCRIPTION
- Enable Jacoco coverage analysis.
- Send the coverage analysis to Coveralls.
- Add a badge showing the coverage on `master`.

Note: this PR is on top of #10.