### PR TITLE
Fix PIT support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -709,6 +709,7 @@
                         <mutators>
                             <mutator>ALL</mutator>
                         </mutators>
+                        <testPlugin>testng</testPlugin>
                         <!-- Use multple threads to speed things up. Extend
                         timeouts to prevent false positives as a result of
                         contention. -->


### PR DESCRIPTION
See hcoles/pitest#458. Now, when running `mvn clean install -Pcoverage` we get
a nice coverage report again.