### PR TITLE
Reorder some `.travis.yml` sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ install:
   - ./mvnw clean install -DskipTests
 script:
   - ./mvnw jacoco:prepare-agent surefire:test jacoco:report coveralls:report sonar:sonar
+before_cache:
+  # Don't cache the artifacts we just generated, for multiple reasons: (1) we
+  # shouldn't need them next time around and (2) if we do, that indicates a
+  # dependency issue which might otherwise go unnoticed until next time we bump
+  # the project's version (i.e., when tagging).
+  - find "${HOME}/.m2/repository" -depth -name '*-SNAPSHOT' -exec rm -r '{}' \;
 cache:
   directories:
     # The local Maven repository in which third party dependencies are stored.
@@ -19,9 +25,3 @@ cache:
     - ${HOME}/.m2/wrapper
     # The SonarQube analysis cache.
     - ${HOME}/.sonar/cache
-before_cache:
-  # Don't cache the artifacts we just generated, for multiple reasons: (1) we
-  # shouldn't need them next time around and (2) if we do, that indicates a
-  # dependency issue which might otherwise go unnoticed until next time we bump
-  # the project's version (i.e., when tagging).
-  - find "${HOME}/.m2/repository" -depth -name '*-SNAPSHOT' -exec rm -r '{}' \;


### PR DESCRIPTION
Logically, `before_cache` comes before `cache`.

Note that this PR is based on #23.