### PR TITLE
Build only against JDK 8 and JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,7 @@ matrix:
         - ./mvnw jacoco:prepare-agent surefire:test jacoco:report coveralls:report sonar:sonar
     - jdk: openjdk8
       script: ./mvnw install
-    - jdk: oraclejdk9
-      script: ./mvnw install
-    - jdk: openjdk9
-      script: ./mvnw install
-    - jdk: oraclejdk10
-      # XXX: On JDK 10 Error Prone causes warnings to be emitted; see
-      # https://github.com/google/error-prone/issues/860.
-      script: ./mvnw install -Dverification.warn
-    - jdk: openjdk10
-      # XXX: On JDK 10 Error Prone causes warnings to be emitted; see
-      # https://github.com/google/error-prone/issues/860.
-      script: ./mvnw install -Dverification.warn
-    - jdk: openjdk-ea
+    - jdk: openjdk11
       # XXX: Error Prone is not yet compatible with JDK 11.
       script: ./mvnw install -Dverification.skip
 addons:


### PR DESCRIPTION
We drop the JDK 9 and JDK 10 builds because these versions are EOL. We drop the
`openjdk-ea` build because it has proven quite unstable over the past months.