### PR TITLE
Auto-verify that the code is formatted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,15 +222,6 @@
                     <groupId>com.coveo</groupId>
                     <artifactId>fmt-maven-plugin</artifactId>
                     <version>2.6.0</version>
-                    <executions>
-                        <execution>
-                            <id>format-sources</id>
-                            <phase>process-sources</phase>
-                            <goals>
-                                <goal>format</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.lewisd</groupId>
@@ -777,6 +768,18 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>com.coveo</groupId>
+                        <artifactId>fmt-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-source-format</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>com.lewisd</groupId>
                         <artifactId>lint-maven-plugin</artifactId>


### PR DESCRIPTION
Execute `fmt:check` as part of the `build-checks` Maven profile. This way we
automatically check whether pull requests are properly formatted.