### PR TITLE
Enable more `forbidden-apis` checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,24 @@
                     </executions>
                     <configuration>
                         <bundledSignatures>
+                            <bundledSignature>jdk-internal</bundledSignature>
+                            <bundledSignature>jdk-non-portable</bundledSignature>
+                            <bundledSignature>jdk-reflection</bundledSignature>
                             <bundledSignature>jdk-system-out</bundledSignature>
+                            <!-- Other bundles are available but currently not
+                            enabled:
+                            - commons-io-unsafe-*: while we may indirectly rely
+                              on Apache Commons IO, we avoid direct
+                              dependencies.
+                            - jdk-deprecated: we compile with `-Xlint:all`,
+                              which causes the build to fail when _any_
+                              deprecated method is called.
+                            - jdk-unsafe: see
+                              https://github.com/policeman-tools/forbidden-apis/issues/119.
+                            Note that this whole plugin could be replaced with
+                            an Error Prone check; that would also make it
+                            possible to resolve issue #119 linked above. See
+                            https://github.com/google/error-prone/issues/632. -->
                         </bundledSignatures>
                         <!-- The plugin tries to load all supertypes of any
                         class it analyzes. Some of those types may be absent


### PR DESCRIPTION
To reduce the delta with internal POMs.