### PR TITLE
Fix PIT JUnit 5 compatibility support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
                         <dependency>
                             <groupId>org.pitest</groupId>
                             <artifactId>pitest-junit5-plugin</artifactId>
-                            <version>0.8</version>
+                            <version>0.10</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,17 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.pitest</groupId>
+                            <artifactId>pitest-junit5-plugin</artifactId>
+                            <version>0.8</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
The migration from TestNG to JUnit 5 broke support for mutation coverage
calculation. This change restores support.

See also hcoles/pitest#284.