### PR TITLE
Replace Coveralls with Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       # coverage and perform a SonarQube analysis.
       script:
         - ./mvnw install
-        - ./mvnw jacoco:prepare-agent surefire:test jacoco:report coveralls:report sonar:sonar
+        - ./mvnw jacoco:prepare-agent surefire:test jacoco:report sonar:sonar
     - jdk: openjdk11
       script: ./mvnw install
 addons:
@@ -28,3 +28,5 @@ cache:
     - ${HOME}/.m2/wrapper
     # The SonarQube analysis cache.
     - ${HOME}/.sonar/cache
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Rationale:
- Coveralls is occasionally unstable, with recently an extended outage.
- trautonen/coveralls-maven-plugin#112 is still not resolved.
- The Codecov user interface is clearer.
- We use Codecov also for an internal project.