### PR TITLE
Run coverage and SonarCloud analysis on JDK 11 rather than JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: java
 matrix:
   include:
     - jdk: openjdk8
+      script: ./mvnw install
+    - jdk: openjdk11
       # This is the primary target platform. In this build we track test
       # coverage and perform a SonarQube analysis.
       script:
         - ./mvnw install
         - ./mvnw jacoco:prepare-agent surefire:test jacoco:report sonar:sonar
-    - jdk: openjdk11
-      script: ./mvnw install
 addons:
   sonarcloud:
     organization: picnic-technologies


### PR DESCRIPTION
SonarCloud analysis no longer supports JDK 8.

See https://sonarcloud.io/documentation/appendices/end-of-support